### PR TITLE
Focus State for Input Fields in Sign In/Sign Up views.

### DIFF
--- a/Apple/ZigZag/ZigZag/Feature/Auth/Component/CreateAccountView.swift
+++ b/Apple/ZigZag/ZigZag/Feature/Auth/Component/CreateAccountView.swift
@@ -11,6 +11,9 @@ struct CreateAccountView: View {
     @EnvironmentObject var viewModel: AuthenticationViewModel
     @EnvironmentObject var navigationManager: AuthNavigationManager
     
+    
+    @FocusState private var isTextFieldFocused: Bool
+    
     @State private var dateOfBirth = Date() // Default to current date
     
     var body: some View {
@@ -32,7 +35,7 @@ struct CreateAccountView: View {
                         .overlay(
                             RoundedRectangle(cornerRadius: 8)
                                 .stroke(Color.gray.opacity(0.5), lineWidth: 1)
-                        )
+                        ).focused($isTextFieldFocused)
                         .onChange(of: viewModel.username, perform: { _ in viewModel.validateUsername() })
                     if let error = viewModel.usernameError {
                         Text(error)
@@ -55,6 +58,7 @@ struct CreateAccountView: View {
                         )
                         .keyboardType(.emailAddress)
                         .autocapitalization(.none)
+                        .focused($isTextFieldFocused)
                         .onChange(of: viewModel.email, perform: { _ in viewModel.validateEmail() })
                     if let error = viewModel.emailError {
                         Text(error)
@@ -70,8 +74,9 @@ struct CreateAccountView: View {
                     HStack {
                         if viewModel.isPasswordVisible {
                             TextField("Enter your password", text: $viewModel.password)
+                                .focused($isTextFieldFocused)
                         } else {
-                            SecureField("Enter your password", text: $viewModel.password)
+                            SecureField("Enter your password", text: $viewModel.password).focused($isTextFieldFocused)
                         }
                         Button(action: {
                             viewModel.togglePasswordVisibility()
@@ -108,6 +113,7 @@ struct CreateAccountView: View {
                                 .stroke(Color.gray.opacity(0.5), lineWidth: 1)
                         )
                         .keyboardType(.phonePad)
+                        .focused($isTextFieldFocused)
                         .onChange(of: viewModel.phoneNumber, perform: { _ in viewModel.validatePhoneNumber() })
                     if let error = viewModel.phoneNumberError {
                         Text(error)
@@ -176,9 +182,12 @@ struct CreateAccountView: View {
                 
                 Spacer()
             }
+            
             .padding()
             .navigationBarBackButtonHidden(true)
             .environmentObject(navigationManager)
+        }.onTapGesture {
+            isTextFieldFocused = false;
         }
     }
 }

--- a/Apple/ZigZag/ZigZag/Feature/Auth/Component/SignInView.swift
+++ b/Apple/ZigZag/ZigZag/Feature/Auth/Component/SignInView.swift
@@ -10,6 +10,8 @@ import SwiftUI
 struct SignInView: View {
     @StateObject var viewModel = AuthenticationViewModel()
     @StateObject var navigationManager = AuthNavigationManager()
+    
+    @FocusState private var isTextFieldFocused: Bool
 
     var body: some View {
         NavigationStack(path: $navigationManager.path) {
@@ -32,6 +34,7 @@ struct SignInView: View {
                     )
                     .keyboardType(.emailAddress)
                     .autocapitalization(.none)
+                    .focused($isTextFieldFocused)
                 
                 // Password Field with Show Toggle
                 Text("Password")
@@ -39,8 +42,10 @@ struct SignInView: View {
                 HStack {
                     if viewModel.isPasswordVisible {
                         TextField("Enter your password", text: $viewModel.password)
+                            .focused($isTextFieldFocused)
                     } else {
                         SecureField("Enter your password", text: $viewModel.password)
+                            .focused($isTextFieldFocused)
                     }
                     Button(action: {
                         viewModel.togglePasswordVisibility()
@@ -102,6 +107,9 @@ struct SignInView: View {
             }
         
             }
+        .onTapGesture {
+            isTextFieldFocused = false;
+        }
         .environmentObject(navigationManager)
         .environmentObject(viewModel)
         }


### PR DESCRIPTION
Added focus state for the input fields in sign in/sign up views so clicking off the input fields closes the keyboards, this is pretty standard behavior in a lot of apps. 